### PR TITLE
Corrected toppage uchida

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
 
 @import "pages/toppage_items_index";
 @import "modules/third-section";
+@import "modules/purchasebtn";

--- a/app/assets/stylesheets/modules/_purchasebtn.scss
+++ b/app/assets/stylesheets/modules/_purchasebtn.scss
@@ -1,0 +1,22 @@
+// 画面右下の固定アイコン
+.purchaseBtn {
+  width: 90px;
+  position: fixed;
+  padding: 15px;
+  bottom: 32px;
+  right: 32px;
+  background-color: $emphasis-color;
+  border-radius: 4%;
+  text-align: center;
+  color: #fff;
+  
+  .purchaseBtn__text {
+    font-size: 18px;
+    margin-bottom: 5px;
+    text-decoration: none;
+    display: block;
+  }
+  .purchaseBtn-icon{
+    width: 54px;
+  }
+}

--- a/app/assets/stylesheets/pages/_toppage_items_index.scss
+++ b/app/assets/stylesheets/pages/_toppage_items_index.scss
@@ -316,26 +316,3 @@
     }
   }
 }
-
-// 画面右下の固定アイコン
-.purchaseBtn {
-  width: 90px;
-  position: fixed;
-  padding: 15px;
-  bottom: 32px;
-  right: 32px;
-  background-color: $emphasis-color;
-  border-radius: 4%;
-  text-align: center;
-  color: #fff;
-  
-  .purchaseBtn__text {
-    font-size: 18px;
-    margin-bottom: 5px;
-    text-decoration: none;
-    display: block;
-  }
-  .purchaseBtn-icon{
-    width: 54px;
-  }
-}

--- a/app/views/items/_purchasebtn.html.haml
+++ b/app/views/items/_purchasebtn.html.haml
@@ -1,0 +1,5 @@
+-# 画面右下の固定アイコン
+=link_to "#" do
+  .purchaseBtn
+    %span.purchaseBtn__text 出品する
+    = image_tag "icon_camera.png", class: "purchaseBtn-icon"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,168 +1,120 @@
--# ファーストビュー
-.main__fv-section
-  %h1.main__fv-section__title 人生を変えるフリマアプリ
-  %p.main__fv-section__text 
-    FURIMAはだれでもかんたんに出品・購入できる
-    %br
-    フリマアプリです
-  .main__fv-section__btn
-    = image_tag "material/logo/app_store_badge_US-UK_RGB_blk_092917.svg", class: "btn_a"
-    = image_tag "material/logo/google-play-badge.png", class: "btn_g"
+-# ヘッダー
+%header
+  = render 'header'
 
-
--# FURIMAが選ばれる3つの理由
-.main__introduction
-  .main__introduction__title
-    FURIMAが選ばれる3つの理由
-  %ul.main__introduction__contents
-    %li.main__introduction__contents__content
-      .main__introduction__contents__content__image
-        = image_tag "material/pict/pict-reason-01.jpg", class:"list-image"
-        .main__introduction__contents__content__image__number 1
-      .main__introduction__contents__content__title 
-        %span.span 3分
-        ですぐに出品
-      .main__introduction__contents__content__text 
-        スマホで入力するだけで簡単に出品できる！
-
-    %li.main__introduction__contents__content
-      .main__introduction__contents__content__image
-        = image_tag "material/pict/pict-reason-02.jpg", class:"list-image"
-        .main__introduction__contents__content__image__number 2
-      .main__introduction__contents__content__title 
-        %span.span シンプル
-        で使いやすい
-      .main__introduction__contents__content__text 
-        めんどくさい入力は必要なく、検索も購入もスムーズ！
-
-    %li.main__introduction__contents__content--last
-      .main__introduction__contents__content__image
-        = image_tag "material/pict/pict-reason-03.jpg", class:"list-image"
-        .main__introduction__contents__content__image__number 3
-      .main__introduction__contents__content__title 
-        手数料
-        %span.span 業界最安
-      .main__introduction__contents__content__text 
-        最大3%でお得に出品＆購入！
-
-
--# セカンドビュー
-.main__middle-section
-  .main__middle-section__content
-    .main__middle-section__content__subtitle
-      会員数日本一位
-    .main__middle-section__content__text
-      FURIMAは、フリマアプリで最も人気。
+.main
+  -# ファーストビュー
+  .main__fv-section
+    %h1.main__fv-section__title 人生を変えるフリマアプリ
+    %p.main__fv-section__text 
+      FURIMAはだれでもかんたんに出品・購入できる
       %br
-      出品・購入回数も業界最多です！
-      %br
-      欲しかったあの商品に出会えるかもしれません。
-    .main__middle-section__content__btn
+      フリマアプリです
+    .main__fv-section__btn
       = image_tag "material/logo/app_store_badge_US-UK_RGB_blk_092917.svg", class: "btn_a"
       = image_tag "material/logo/google-play-badge.png", class: "btn_g"
 
 
--# FURIMAの特徴
-.main__app-feature
-  .main__app-feature__title
-    FURIMAの特徴
-  %ul.main__app-feature__lists
-    -# 特徴その1
-    %li.main__app-feature__lists__content
-      .main__app-feature__lists__content__image
-        = image_tag "material/icon/icon-01.png", class:"list-image"
-      .main__app-feature__lists__content__title
-        簡単に売り買いできる
-      .main__app-feature__lists__content__text
-        スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
-    -# 特徴その2
-    %li.main__app-feature__lists__content
-      .main__app-feature__lists__content__image
-        = image_tag "material/icon/icon-03.png", class:"list-image"
-      .main__app-feature__lists__content__title
-        売上金は即日振込みに対応
-      .main__app-feature__lists__content__text
-        午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします！
-    -# 特徴その3
-    %li.main__app-feature__lists__content
-      .main__app-feature__lists__content__image
-        = image_tag "material/icon/icon-04.png", class:"list-image"
-      .main__app-feature__lists__content__title
-        様々な支払いに対応
-      .main__app-feature__lists__content__text
-        お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
+  -# FURIMAが選ばれる3つの理由
+  .main__introduction
+    .main__introduction__title
+      FURIMAが選ばれる3つの理由
+    %ul.main__introduction__contents
+      %li.main__introduction__contents__content
+        .main__introduction__contents__content__image
+          = image_tag "material/pict/pict-reason-01.jpg", class:"list-image"
+          .main__introduction__contents__content__image__number 1
+        .main__introduction__contents__content__title 
+          %span.span 3分
+          ですぐに出品
+        .main__introduction__contents__content__text 
+          スマホで入力するだけで簡単に出品できる！
+
+      %li.main__introduction__contents__content
+        .main__introduction__contents__content__image
+          = image_tag "material/pict/pict-reason-02.jpg", class:"list-image"
+          .main__introduction__contents__content__image__number 2
+        .main__introduction__contents__content__title 
+          %span.span シンプル
+          で使いやすい
+        .main__introduction__contents__content__text 
+          めんどくさい入力は必要なく、検索も購入もスムーズ！
+
+      %li.main__introduction__contents__content--last
+        .main__introduction__contents__content__image
+          = image_tag "material/pict/pict-reason-03.jpg", class:"list-image"
+          .main__introduction__contents__content__image__number 3
+        .main__introduction__contents__content__title 
+          手数料
+          %span.span 業界最安
+        .main__introduction__contents__content__text 
+          最大3%でお得に出品＆購入！
 
 
--# ピックアップカテゴリー
-.main__pickup-category
-  .main__pickup-category__title
-    ピックアップカテゴリー
-  .main__pickup-category__contents
-    .main__pickup-category__contents__title
-      =link_to "新規投稿商品","/",class:"pickup-category-title"
-    .main__pickup-category__contents__items
-      -# 以下、item1
-      -# 以下の#部分をitem/idに変更する予定
-      =link_to "#" do
-        .main__pickup-category__contents__items__item
-          .main__pickup-category__contents__items__item__image
-            = image_tag "material/icon/icon-04.png", class:"pickup-category-item"
-          .main__pickup-category__contents__items__item__info
-            %h3.name item1
-            .main__pickup-category__contents__items__item__info__detail
-              %ul
-                %li 30000円
-                %li
-                  = icon('fa', 'star')
-                  0
-              %p (税込)
-      -# item2
-      =link_to "#" do
-        .main__pickup-category__contents__items__item
-          .main__pickup-category__contents__items__item__image
-            = image_tag "material/icon/icon-04.png", class:"pickup-category-item"
-          .main__pickup-category__contents__items__item__info
-            %h3.name item2
-            .main__pickup-category__contents__items__item__info__detail
-              %ul
-                %li 20000円
-                %li
-                  = icon('fa', 'star')
-                  0
-              %p (税込)
-      -# item3
-      =link_to "#" do
-        .main__pickup-category__contents__items__item
-          .main__pickup-category__contents__items__item__image
-            = image_tag "material/icon/icon-04.png", class:"pickup-category-item"
-          .main__pickup-category__contents__items__item__info
-            %h3.name item3
-            .main__pickup-category__contents__items__item__info__detail
-              %ul
-                %li 10000円
-                %li
-                  = icon('fa', 'star')
-                  0
-              %p (税込)
+  -# セカンドビュー
+  .main__middle-section
+    .main__middle-section__content
+      .main__middle-section__content__subtitle
+        会員数日本一位
+      .main__middle-section__content__text
+        FURIMAは、フリマアプリで最も人気。
+        %br
+        出品・購入回数も業界最多です！
+        %br
+        欲しかったあの商品に出会えるかもしれません。
+      .main__middle-section__content__btn
+        = image_tag "material/logo/app_store_badge_US-UK_RGB_blk_092917.svg", class: "btn_a"
+        = image_tag "material/logo/google-play-badge.png", class: "btn_g"
 
 
--# ピックアップブランド
-.main__pickup-brand
-  .main__pickup-brand__title
-    ピックアップブランド
-  .main__pickup-brand__contents
-    .main__pickup-brand__contents__title
-      -# 以下の#部分をitem/idに変更する予定
-      = link_to "アーカイバ","/",class:"pickup-brand-title"
-      .main__pickup-brand__contents__items
+  -# FURIMAの特徴
+  .main__app-feature
+    .main__app-feature__title
+      FURIMAの特徴
+    %ul.main__app-feature__lists
+      -# 特徴その1
+      %li.main__app-feature__lists__content
+        .main__app-feature__lists__content__image
+          = image_tag "material/icon/icon-01.png", class:"list-image"
+        .main__app-feature__lists__content__title
+          簡単に売り買いできる
+        .main__app-feature__lists__content__text
+          スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
+      -# 特徴その2
+      %li.main__app-feature__lists__content
+        .main__app-feature__lists__content__image
+          = image_tag "material/icon/icon-03.png", class:"list-image"
+        .main__app-feature__lists__content__title
+          売上金は即日振込みに対応
+        .main__app-feature__lists__content__text
+          午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします！
+      -# 特徴その3
+      %li.main__app-feature__lists__content
+        .main__app-feature__lists__content__image
+          = image_tag "material/icon/icon-04.png", class:"list-image"
+        .main__app-feature__lists__content__title
+          様々な支払いに対応
+        .main__app-feature__lists__content__text
+          お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
+
+
+  -# ピックアップカテゴリー
+  .main__pickup-category
+    .main__pickup-category__title
+      ピックアップカテゴリー
+    .main__pickup-category__contents
+      .main__pickup-category__contents__title
+        =link_to "新規投稿商品","/",class:"pickup-category-title"
+      .main__pickup-category__contents__items
         -# 以下、item1
-        = link_to "#" do
-          .main__pickup-brand__contents__items__item
-            .main__pickup-brand__contents__items__item__image
-              = image_tag "material/icon/icon-04.png", class:"pickup-brand-item"
-            .main__pickup-brand__contents__items__item__info
+        -# 以下の#部分をitem/idに変更する予定
+        =link_to "#" do
+          .main__pickup-category__contents__items__item
+            .main__pickup-category__contents__items__item__image
+              = image_tag "material/icon/icon-04.png", class:"pickup-category-item"
+            .main__pickup-category__contents__items__item__info
               %h3.name item1
-              .main__pickup-brand__contents__items__item__info__detail
+              .main__pickup-category__contents__items__item__info__detail
                 %ul
                   %li 30000円
                   %li
@@ -170,13 +122,13 @@
                     0
                 %p (税込)
         -# item2
-        = link_to "#" do
-          .main__pickup-brand__contents__items__item
-            .main__pickup-brand__contents__items__item__image
-              = image_tag "material/icon/icon-04.png", class:"pickup-brand-item"
-            .main__pickup-brand__contents__items__item__info
+        =link_to "#" do
+          .main__pickup-category__contents__items__item
+            .main__pickup-category__contents__items__item__image
+              = image_tag "material/icon/icon-04.png", class:"pickup-category-item"
+            .main__pickup-category__contents__items__item__info
               %h3.name item2
-              .main__pickup-brand__contents__items__item__info__detail
+              .main__pickup-category__contents__items__item__info__detail
                 %ul
                   %li 20000円
                   %li
@@ -184,13 +136,13 @@
                     0
                 %p (税込)
         -# item3
-        = link_to "#" do
-          .main__pickup-brand__contents__items__item
-            .main__pickup-brand__contents__items__item__image
-              = image_tag "material/icon/icon-04.png", class:"pickup-brand-item"
-            .main__pickup-brand__contents__items__item__info
+        =link_to "#" do
+          .main__pickup-category__contents__items__item
+            .main__pickup-category__contents__items__item__image
+              = image_tag "material/icon/icon-04.png", class:"pickup-category-item"
+            .main__pickup-category__contents__items__item__info
               %h3.name item3
-              .main__pickup-brand__contents__items__item__info__detail
+              .main__pickup-category__contents__items__item__info__detail
                 %ul
                   %li 10000円
                   %li
@@ -199,9 +151,68 @@
                 %p (税込)
 
 
--# サードビュー
-.main__third-section
-  = render 'third-section'
+  -# ピックアップブランド
+  .main__pickup-brand
+    .main__pickup-brand__title
+      ピックアップブランド
+    .main__pickup-brand__contents
+      .main__pickup-brand__contents__title
+        -# 以下の#部分をitem/idに変更する予定
+        = link_to "アーカイバ","/",class:"pickup-brand-title"
+        .main__pickup-brand__contents__items
+          -# 以下、item1
+          = link_to "#" do
+            .main__pickup-brand__contents__items__item
+              .main__pickup-brand__contents__items__item__image
+                = image_tag "material/icon/icon-04.png", class:"pickup-brand-item"
+              .main__pickup-brand__contents__items__item__info
+                %h3.name item1
+                .main__pickup-brand__contents__items__item__info__detail
+                  %ul
+                    %li 30000円
+                    %li
+                      = icon('fa', 'star')
+                      0
+                  %p (税込)
+          -# item2
+          = link_to "#" do
+            .main__pickup-brand__contents__items__item
+              .main__pickup-brand__contents__items__item__image
+                = image_tag "material/icon/icon-04.png", class:"pickup-brand-item"
+              .main__pickup-brand__contents__items__item__info
+                %h3.name item2
+                .main__pickup-brand__contents__items__item__info__detail
+                  %ul
+                    %li 20000円
+                    %li
+                      = icon('fa', 'star')
+                      0
+                  %p (税込)
+          -# item3
+          = link_to "#" do
+            .main__pickup-brand__contents__items__item
+              .main__pickup-brand__contents__items__item__image
+                = image_tag "material/icon/icon-04.png", class:"pickup-brand-item"
+              .main__pickup-brand__contents__items__item__info
+                %h3.name item3
+                .main__pickup-brand__contents__items__item__info__detail
+                  %ul
+                    %li 10000円
+                    %li
+                      = icon('fa', 'star')
+                      0
+                  %p (税込)
+
+
+  -# サードビュー
+  .main__third-section
+    = render 'third-section'
+
+
+-# フッター
+%footer
+  = render 'items/footer'
+
 
 
 -# 画面右下の固定アイコン

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -209,9 +209,9 @@
     = render 'third-section'
 
 
--# フッター
+-# フッダー
 %footer
-  = render 'items/footer'
+  = render 'footer'
 
 
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -216,7 +216,4 @@
 
 
 -# 画面右下の固定アイコン
-=link_to "#" do
-  .purchaseBtn
-    %span.purchaseBtn__text 出品する
-    = image_tag "icon_camera.png", class: "purchaseBtn-icon"
+= render 'purchasebtn'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,3 +9,4 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = yield
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,11 +8,4 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-    %header
-      = render 'items/header'
-      
-    .main
-      = yield
-
-    %footer
-      = render 'items/footer'
+    = yield


### PR DESCRIPTION
# What
1. application.html.hamlからheaderとfooter、mainの記述を削除し、body内を「=yield」のみに修正した。それに伴い、index.html.haml内の記述も修正。（headerとfooterをrenderで追加。また、インデントを微修正。）
2. 出品ボタン部分のhtmlとscssを部分テンプレートとして切り出した。

# Why
headerとfooterを使用しない画面もある為、application.html.haml内の記述を修正した。
また、出品ボタンは他画面でも使用する為。